### PR TITLE
warns: fix bot not replying during bans

### DIFF
--- a/tg_bot/modules/warns.py
+++ b/tg_bot/modules/warns.py
@@ -64,7 +64,7 @@ def warn(user: User,
             reply += "\n - {}".format(html.escape(warn_reason))
 
         message.bot.send_sticker(chat.id, BAN_STICKER)  # ban sticker
-        keyboard = []
+        keyboard = {}
         log_reason = "<b>{}:</b>" \
                      "\n#WARN_BAN" \
                      "\n<b>Admin:</b> {}" \


### PR DESCRIPTION
- fixes bot not replying when banning after exceeding certain numbers of warns